### PR TITLE
Resolved issue for remote clients behind NAT

### DIFF
--- a/frosthaven_assistant/lib/services/network/connection.dart
+++ b/frosthaven_assistant/lib/services/network/connection.dart
@@ -19,10 +19,10 @@ class Connection {
 
   Future<List<InternetAddress>> _resolveAddress(String address) async {
     List<InternetAddress> resolvedAddresses =
-          await InternetAddress.lookup(address);
-      if (resolvedAddresses.isEmpty) {
-        throw Exception("Unable to resolve host");
-      }
+        await InternetAddress.lookup(address);
+    if (resolvedAddresses.isEmpty) {
+      throw Exception("Unable to resolve host");
+    }
     return resolvedAddresses;
   }
 
@@ -54,7 +54,9 @@ class Connection {
   }
 
   Iterable<Socket> _find(Socket socket) {
-    return _sockets.where((x) => x.remoteAddress == socket.remoteAddress);
+    return _sockets.where((x) =>
+        x.remoteAddress == socket.remoteAddress &&
+        x.remotePort == socket.remotePort);
   }
 
   void _destroy(Iterable<Socket> sockets) {


### PR DESCRIPTION
Original Issue: When multiple client applications are running on the same network and sharing the same external IP address, only 1 could be connected at any one time. As soon as a second client attempted to connect, the first client would be immediately disconnected.

Resolution: When adding a new connection, the application first checks for duplicate connections and closes them. This duplicate connection check only compared remote IP addresses, meaning it gave false positives for multiple clients behind common NAT configurations. This fix changes the duplicate check to confirm that both the IP address and remote port are the same before closing the connection.